### PR TITLE
Bugfix/issue #5 horizontal scrolling content in stick header prevents display

### DIFF
--- a/Sources/SwiftyDrawer/Drawer.swift
+++ b/Sources/SwiftyDrawer/Drawer.swift
@@ -19,6 +19,9 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
     @Environment(\.drawerFloatingButtonsConfiguration)
     private var floatingButtonsConfiguration: DrawerFloatingButtonsConfiguration
 
+    @Environment(\.isApplyingRenderingOptimizationToDrawerHeader)
+    private var isApplyingRenderingOptimizationToDrawerHeader: Bool
+
     @Environment(\.drawerContentOffsetController)
     var contentOffsetController: DrawerContentOffsetController?
 
@@ -183,7 +186,7 @@ extension Drawer {
         }
         .fixedSize(horizontal: false, vertical: true)
         .background { style.backgroundColor }
-        .drawingGroup()
+        .drawingGroup(isEnabled: isApplyingRenderingOptimizationToDrawerHeader)
         .background {
             PrerenderedShadowView(
                 configuration: .init(

--- a/Sources/SwiftyDrawer/Drawer.swift
+++ b/Sources/SwiftyDrawer/Drawer.swift
@@ -113,7 +113,7 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
                 .zIndex(0)
             }
             .frame(height: positionCalculator.screenHeight)
-            .background(Color.background)
+            .background { Color.background }
             .roundedCorners(style.cornerRadius, corners: [.topLeft, .topRight])
             .prerenderedShadow(style.shadowStyle, cornerRadius: style.cornerRadius)
             .gesture(dragGesture)
@@ -182,7 +182,7 @@ extension Drawer {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
-        .background(style.backgroundColor)
+        .background { style.backgroundColor }
         .drawingGroup()
         .background {
             PrerenderedShadowView(

--- a/Sources/SwiftyDrawer/EnvironmentValues+Drawer.swift
+++ b/Sources/SwiftyDrawer/EnvironmentValues+Drawer.swift
@@ -12,6 +12,8 @@ extension EnvironmentValues {
         trailingButtons: []
     )
 
+    @Entry var isApplyingRenderingOptimizationToDrawerHeader = true
+
     @Entry var drawerContentOffsetController: DrawerContentOffsetController?
     @Entry var drawerOriginObservable: DrawerOriginObservable?
 
@@ -38,6 +40,11 @@ public extension View {
 
     func drawerFloatingButtonsConfiguration(_ configuration: DrawerFloatingButtonsConfiguration) -> some View {
         environment(\.drawerFloatingButtonsConfiguration, configuration)
+    }
+
+    /// By default, the drawer header  is using a `drawingGroup` modifier to prevent glitchy animations when dragging the drawer or changing its state programmatically. Unfortunately this comes with some implications, for example the inability to use a `ScrollView` or any other view backed by native platform, which are simply not rendered. Use this environment value to disable this optimization.
+    func isApplyingRenderingOptimizationToDrawerHeader(_ isApplying: Bool) -> some View {
+        environment(\.isApplyingRenderingOptimizationToDrawerHeader, isApplying)
     }
 
     func drawerContentOffsetController(_ controller: DrawerContentOffsetController?) -> some View {

--- a/Sources/SwiftyDrawer/Extensions/View+DrawingGroup.swift
+++ b/Sources/SwiftyDrawer/Extensions/View+DrawingGroup.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func drawingGroup(
+        isEnabled: Bool,
+        opaque: Bool = false,
+        colorMode: ColorRenderingMode = .nonLinear
+    ) -> some View {
+        if isEnabled {
+            self.drawingGroup(opaque: opaque, colorMode: colorMode)
+        } else {
+            self
+        }
+    }
+}

--- a/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
+++ b/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
@@ -6,7 +6,7 @@ struct ContentView: View {
     @State private var drawerBottomPosition = DrawerBottomPosition.relativeToSafeAreaBottom(offset: 0)
 
     @State private var isTabBarShown = false
-    @State private var isStickyHeaderShown = true
+    @State private var isStickyHeaderShown = false
     @State private var isCustomDragHandleShown = false
     @State private var isStickyHeaderScrollable = false
 

--- a/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
+++ b/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
@@ -6,8 +6,9 @@ struct ContentView: View {
     @State private var drawerBottomPosition = DrawerBottomPosition.relativeToSafeAreaBottom(offset: 0)
 
     @State private var isTabBarShown = false
-    @State private var isStickyHeaderShown = false
+    @State private var isStickyHeaderShown = true
     @State private var isCustomDragHandleShown = false
+    @State private var isStickyHeaderScrollable = false
 
     private let floatingButtonsConfig = DrawerFloatingButtonsConfiguration(
         trailingButtons: [
@@ -30,6 +31,7 @@ struct ContentView: View {
                 )
                 .drawerFloatingButtonsConfiguration(floatingButtonsConfig)
                 .isDrawerHapticFeedbackEnabled(true)
+                .isApplyingRenderingOptimizationToDrawerHeader(!isStickyHeaderScrollable)
         }
         .onChange(of: isStickyHeaderShown) { newValue in
             updateDrawerBottomPosition(
@@ -71,7 +73,7 @@ struct ContentView: View {
             )
 
             Toggle("Show sticky header", isOn: $isStickyHeaderShown)
-
+            Toggle("Sticky header is scrollable", isOn: $isStickyHeaderScrollable)
             Toggle("Show custom drag handle", isOn: $isCustomDragHandleShown)
 
             LazyVGrid(columns: [.init(.flexible()), .init(.flexible())]) {
@@ -106,18 +108,40 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
+    @ViewBuilder
     var stickyDrawerHeader: some View {
-        VStack(spacing: 0) {
-            Text("Sticky header")
-                .font(.title)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .padding(.horizontal)
+        if isStickyHeaderScrollable {
+            ScrollView(.horizontal) {
+                HStack(spacing: 0) {
+                    ForEach(0..<3) { index in
+                        stickyHeaderText(title: "Sticky header item \(index)")
+                    }
+                }
+            }
+            .background { Color.teal }
+        } else {
+            VStack(spacing: 0) {
+                stickyHeaderText(
+                    title: "Sticky header",
+                    isShowingDivider: true
+                )
+            }
+            .background { Color.teal }
+        }
+    }
 
+    @ViewBuilder
+    func stickyHeaderText(title: String, isShowingDivider: Bool = false) -> some View {
+        Text(title)
+            .font(.title)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .padding(.horizontal)
+
+        if isShowingDivider {
             Color.black.opacity(0.3)
                 .frame(height: 1)
         }
-        .background { Color.teal }
     }
 
     var drawerContent: some View {


### PR DESCRIPTION
## Issue
https://github.com/aswinter90/SwiftyDrawer/issues/5

## Done
As described in the issue the drawer is currently not capable of showing ScrollViews in its sticky header because views like that cannot be rendered due to the `drawingGroup` modifier of the container. This modifier was originally introduced to prevent the header from showing ugly animation glitches during interactions with the drawer, especially when modifying its state (e.g. the `drawerBottomPosition`) programmatically.
Since the tradeoff is rather small I decided to introduce a new environment variable `isApplyingRenderingOptimizationToDrawerHeader` which can be accessed to disable the `drawingGroup` modifier. This way we can also show ScrollViews inside the sticky header.

The advanced demo also got an update to showcase this new behavior.

## Result
![result](https://github.com/user-attachments/assets/f0df72d1-adab-413a-b779-03f1e02c3f24)

## BUT:
![tradeoff](https://github.com/user-attachments/assets/72585d7b-76af-43eb-bd92-11ddbfc8aed8)