### PR TITLE
Bugfix/drawer background color

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftyDrawer",
-            swiftSettings: [.defaultIsolation(MainActor.self)],
             plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")]
         ),
         .testTarget(

--- a/Sources/SwiftyDrawer/ChildViews/DrawerContentCollectionView/DrawerContentCollectionView.swift
+++ b/Sources/SwiftyDrawer/ChildViews/DrawerContentCollectionView/DrawerContentCollectionView.swift
@@ -35,7 +35,7 @@ class DrawerContentCollectionView<Content: View>: UICollectionView, UICollection
     private let configuration: UICollectionLayoutListConfiguration = {
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
         configuration.showsSeparators = false
-        configuration.backgroundColor = .init(.background)
+        configuration.backgroundColor = .clear
         return configuration
     }()
 
@@ -44,9 +44,12 @@ class DrawerContentCollectionView<Content: View>: UICollectionView, UICollection
             let hostingConfiguration = UIHostingConfiguration { content }
                 .margins(.horizontal, 0)
                 .margins(.vertical, 0)
-            
+
             collectionViewCell.contentConfiguration = hostingConfiguration
-            collectionViewCell.contentView.backgroundColor = .init(.background)
+            collectionViewCell.backgroundView = .init()
+            collectionViewCell.backgroundView?.backgroundColor = .clear
+            collectionViewCell.backgroundColor = .clear
+            collectionViewCell.contentView.backgroundColor = .clear
         } else {
             fatalError("DrawerContentCollectionView is only available on iOS 16+")
         }

--- a/Sources/SwiftyDrawer/ChildViews/DrawerContentCollectionView/LegacyDrawerContentCollectionView.swift
+++ b/Sources/SwiftyDrawer/ChildViews/DrawerContentCollectionView/LegacyDrawerContentCollectionView.swift
@@ -73,7 +73,7 @@ class LegacyDrawerContentCollectionView<Content: View>: UICollectionView, UIColl
             forCellWithReuseIdentifier: String(describing: UICollectionViewCell.self)
         )
         dataSource = self
-        backgroundColor = .init(.background)
+        backgroundColor = .clear
         delegate = self
     }
 
@@ -118,6 +118,9 @@ class LegacyDrawerContentCollectionView<Content: View>: UICollectionView, UIColl
             withReuseIdentifier: String(describing: UICollectionViewCell.self),
             for: indexPath
         )
+        cell.backgroundColor = .clear
+        cell.backgroundView = .init()
+        cell.backgroundView?.backgroundColor = .clear
 
         let contentView = cell.contentView
 
@@ -133,7 +136,9 @@ class LegacyDrawerContentCollectionView<Content: View>: UICollectionView, UIColl
 
         guard let hostingView = UIHostingController(rootView: view).view else { return .init() }
 
-        contentView.backgroundColor = .init(.background)
+        hostingView.backgroundColor = .clear
+
+        contentView.backgroundColor = .clear
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([

--- a/Sources/SwiftyDrawer/Drawer.swift
+++ b/Sources/SwiftyDrawer/Drawer.swift
@@ -105,7 +105,7 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
                     content:
                         content
                             .fixedSize(horizontal: false, vertical: true)
-                            .if(condition: layoutStrategy == .modern) {
+                            .if(layoutStrategy == .modern) {
                                 // Fixme: For the `classic` strategy the padding had to be added in `LegacyDrawerContentCollectionView`
                                 $0.padding(.bottom, positionCalculator.contentBottomPadding)
                             }
@@ -115,7 +115,9 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
             .frame(height: positionCalculator.drawerHeight)
             .background(style.backgroundColor)
             .roundedCorners(style.cornerRadius, corners: [.topLeft, .topRight])
-            .prerenderedShadow(style.shadowStyle, cornerRadius: style.cornerRadius)
+            .if(style.hasOpaqueBackgroundColor) {
+                $0.prerenderedShadow(style.shadowStyle, cornerRadius: style.cornerRadius)
+            }
             .gesture(dragGesture)
             .onAppear { stateReducer.syncCaseAndCurrentPosition(of: &state) }
             .onChange(of: state.case) { [oldCase = state.case] newCase in
@@ -184,18 +186,20 @@ extension Drawer {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
-        .background { style.backgroundColor }
         .drawingGroup(isEnabled: isApplyingRenderingOptimizationToDrawerHeader)
-        .background {
-            PrerenderedShadowView(
-                configuration: .init(
-                    style: style.stickyHeaderShadowStyle,
-                    cornerRadius: 0
-                )
-            )
-            .swiftUIView
-            .opacity(shouldElevateStickyHeader ? 1 : 0)
-            .padding(.horizontal, -8)
+        .if(style.hasOpaqueBackgroundColor) {
+            $0.background { style.backgroundColor }
+                .background {
+                    PrerenderedShadowView(
+                        configuration: .init(
+                            style: style.stickyHeaderShadowStyle,
+                            cornerRadius: 0
+                        )
+                    )
+                    .swiftUIView
+                    .opacity(shouldElevateStickyHeader ? 1 : 0)
+                    .padding(.horizontal, -8)
+                }
         }
         // The `readSize`-closures above are not always called when using SwiftUI previews after updating the sticky header content or changing one of the drawer's fixed positions on the outside.
         // By changing the view ids in `redrawHeader` we trigger a redraw and can make sure we always re-read their sizes.

--- a/Sources/SwiftyDrawer/Drawer.swift
+++ b/Sources/SwiftyDrawer/Drawer.swift
@@ -105,7 +105,6 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
                     content:
                         content
                             .fixedSize(horizontal: false, vertical: true)
-                            .background(style.backgroundColor)
                             .if(condition: layoutStrategy == .modern) {
                                 // Fixme: For the `classic` strategy the padding had to be added in `LegacyDrawerContentCollectionView`
                                 $0.padding(.bottom, positionCalculator.contentBottomPadding)
@@ -114,7 +113,7 @@ public struct Drawer<Content: View, HeaderContent: View>: View {
                 .zIndex(0)
             }
             .frame(height: positionCalculator.drawerHeight)
-            .background { Color.background }
+            .background(style.backgroundColor)
             .roundedCorners(style.cornerRadius, corners: [.topLeft, .topRight])
             .prerenderedShadow(style.shadowStyle, cornerRadius: style.cornerRadius)
             .gesture(dragGesture)
@@ -185,7 +184,6 @@ extension Drawer {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
-        .background { style.backgroundColor }
         .drawingGroup(isEnabled: isApplyingRenderingOptimizationToDrawerHeader)
         .background {
             PrerenderedShadowView(

--- a/Sources/SwiftyDrawer/Drawer.swift
+++ b/Sources/SwiftyDrawer/Drawer.swift
@@ -184,6 +184,7 @@ extension Drawer {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
+        .background { style.backgroundColor }
         .drawingGroup(isEnabled: isApplyingRenderingOptimizationToDrawerHeader)
         .background {
             PrerenderedShadowView(

--- a/Sources/SwiftyDrawer/Extensions/View+Condition.swift
+++ b/Sources/SwiftyDrawer/Extensions/View+Condition.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension View {
     @ViewBuilder
-    func `if`<Content: View>(condition: Bool, content: @escaping (Self) -> Content) -> some View {
+    func `if`<Content: View>(_ condition: Bool, content: @escaping (Self) -> Content) -> some View {
         if condition {
             content(self)
         } else {

--- a/Sources/SwiftyDrawer/Models/DrawerStyle.swift
+++ b/Sources/SwiftyDrawer/Models/DrawerStyle.swift
@@ -37,6 +37,10 @@ public struct DrawerStyle {
             self.radius = radius
             self.offset = offset
         }
+
+        public static var none: Self {
+            Self.init(color: .clear, offset: .init(width: 0, height: 0))
+        }
     }
 
     let backgroundColor: Color

--- a/Sources/SwiftyDrawer/Models/DrawerStyle.swift
+++ b/Sources/SwiftyDrawer/Models/DrawerStyle.swift
@@ -38,7 +38,9 @@ public struct DrawerStyle {
             self.offset = offset
         }
 
+        // swiftlint:disable:next discouraged_none_name
         public static var none: Self {
+            // swiftlint:disable:next explicit_init
             Self.init(color: .clear, offset: .init(width: 0, height: 0))
         }
     }

--- a/Sources/SwiftyDrawer/Models/DrawerStyle.swift
+++ b/Sources/SwiftyDrawer/Models/DrawerStyle.swift
@@ -49,6 +49,11 @@ public struct DrawerStyle {
     let dragHandleStyle: DragHandleStyle
     let stickyHeaderShadowStyle: ShadowStyle
 
+    var hasOpaqueBackgroundColor: Bool {
+        let color = UIColor(backgroundColor)
+        return color.cgColor.alpha == 1 && color != .clear
+    }
+
     public init(
         backgroundColor: Color = Color.background,
         cornerRadius: Double = DrawerConstants.drawerCornerRadius,

--- a/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
+++ b/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
@@ -6,10 +6,10 @@ struct ContentView: View {
     @State private var drawerBottomPosition = DrawerBottomPosition.relativeToSafeAreaBottom(offset: 0)
 
     @State private var isTabBarShown = false
-    @State private var isStickyHeaderShown = true
+    @State private var isStickyHeaderShown = false
+    @State private var isStickyHeaderScrollable = false
     @State private var isCustomDragHandleShown = false
     @State private var isDrawerTransparent = false
-    @State private var isStickyHeaderScrollable = false
 
     private let floatingButtonsConfig = DrawerFloatingButtonsConfiguration(
         trailingButtons: [
@@ -31,7 +31,7 @@ struct ContentView: View {
                     content: { drawerContent }
                 )
                 .drawerStyle(
-                    isDrawerTransparent ? .init(backgroundColor: .red.opacity(0.3)) : .init()
+                    isDrawerTransparent ? .init(backgroundColor: .clear) : .init()
                 )
                 .drawerLayoutStrategy(.classic)
                 .drawerFloatingButtonsConfiguration(floatingButtonsConfig)

--- a/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
+++ b/SwiftyDrawer-Demo/SwiftyDrawer-Advanced-Demo/ContentView.swift
@@ -6,8 +6,9 @@ struct ContentView: View {
     @State private var drawerBottomPosition = DrawerBottomPosition.relativeToSafeAreaBottom(offset: 0)
 
     @State private var isTabBarShown = false
-    @State private var isStickyHeaderShown = false
+    @State private var isStickyHeaderShown = true
     @State private var isCustomDragHandleShown = false
+    @State private var isDrawerTransparent = false
     @State private var isStickyHeaderScrollable = false
 
     private let floatingButtonsConfig = DrawerFloatingButtonsConfiguration(
@@ -28,6 +29,9 @@ struct ContentView: View {
                     isDimmingBackground: true,
                     stickyHeader: { isStickyHeaderShown ? stickyDrawerHeader : nil },
                     content: { drawerContent }
+                )
+                .drawerStyle(
+                    isDrawerTransparent ? .init(backgroundColor: .red.opacity(0.3)) : .init()
                 )
                 .drawerLayoutStrategy(.classic)
                 .drawerFloatingButtonsConfiguration(floatingButtonsConfig)
@@ -57,6 +61,7 @@ struct ContentView: View {
             Toggle("Show sticky header", isOn: $isStickyHeaderShown)
             Toggle("Sticky header is scrollable", isOn: $isStickyHeaderScrollable)
             Toggle("Show custom drag handle", isOn: $isCustomDragHandleShown)
+            Toggle("Make drawer transparent", isOn: $isDrawerTransparent)
 
             LazyVGrid(columns: [.init(.flexible()), .init(.flexible())]) {
                 Text("Set state to:")


### PR DESCRIPTION
# Done
- Refactored the drawer to correctly show the background color set in `DrawerStyle`
- Removed the default MainActor isolation from the package as it caused crashes when not background color was passed from the outside 🤷‍♂️
- Added a toggle to the advanced demo for making the drawer transparent

<img width="450" height="978" alt="image" src="https://github.com/user-attachments/assets/3ab8655d-d58e-4480-8acc-b090a5c85681" />
